### PR TITLE
chore: add weekly Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly updates for GitHub Actions and pip dependencies.

Resolves #6

## Test plan
- [ ] Confirm Dependabot picks up the file after merge
- [ ] Confirm weekly GitHub Actions and pip update PRs can be opened

## Summary by Sourcery

Chores:
- Add Dependabot configuration for weekly updates to GitHub Actions and pip dependencies, limiting open pip update pull requests to 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled weekly automated dependency update checks for GitHub Actions and Python packages.
  * Limited open Python dependency update pull requests to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->