### PR TITLE
chore: replace flake8, isort, and black with Ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,20 @@
+name: Ruff
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  ruff:
+    name: Lint and format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check .
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check .

--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,15 @@ Regenerate translation files:
 
    make localegen
 
+Lint and format Python with Ruff:
+
+.. code-block:: bash
+
+   ruff check .
+   ruff check . --fix
+   ruff format --check .
+   ruff format .
+
 Run tests, if tests are available in the checkout:
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -85,13 +85,13 @@ From the ``eventyay-paypal`` directory, install the plugin in editable mode.
 
 .. code-block:: bash
 
-   pip install -e .
+   pip install -e ".[dev]"
 
 If your Eventyay development setup uses ``uv``, you can also use:
 
 .. code-block:: bash
 
-   uv pip install -e .
+   uv pip install -e ".[dev]"
 
 5. Apply migrations
 ~~~~~~~~~~~~~~~~~~~
@@ -144,7 +144,7 @@ PayPal Connect
 
 PayPal Connect allows an organiser to connect an event to a PayPal account through the Eventyay payment settings.
 
-When PayPal Connect is configured globally, the organiser sees a connect button in the event payment settings. After the account has been connected successfully, Eventyay stores the PayPal account reference for the event.
+When PayPal Connect is configured globally, the event payment settings show a **Connect with PayPal** OAuth button. Organisers can create a PayPal account or link an existing one without pasting API keys. After a successful connection, Eventyay stores the PayPal merchant reference for the event and enables PayPal payments.
 
 Global PayPal Connect settings include:
 
@@ -253,7 +253,7 @@ Install the plugin in editable mode:
 
 .. code-block:: bash
 
-   pip install -e .
+   pip install -e ".[dev]"
 
 Compile translations:
 

--- a/eventyay_paypal/__init__.py
+++ b/eventyay_paypal/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "1.0.0"
-default_app_config = 'eventyay-paypal.apps.PaypalPluginApp'
+default_app_config = "eventyay-paypal.apps.PaypalPluginApp"

--- a/eventyay_paypal/migrations/0001_initial.py
+++ b/eventyay_paypal/migrations/0001_initial.py
@@ -5,25 +5,21 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+
     initial = True
 
     dependencies = [
-        ("base", "0001_initial"),
+        ('base', '0001_initial'),
     ]
 
     operations = [
         migrations.CreateModel(
-            name="ReferencedPayPalObject",
+            name='ReferencedPayPalObject',
             fields=[
-                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
-                ("reference", models.CharField(db_index=True, max_length=190, unique=True)),
-                ("order", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="base.order")),
-                (
-                    "payment",
-                    models.ForeignKey(
-                        blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to="base.orderpayment"
-                    ),
-                ),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('reference', models.CharField(db_index=True, max_length=190, unique=True)),
+                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='base.order')),
+                ('payment', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='base.orderpayment')),
             ],
         ),
     ]

--- a/eventyay_paypal/migrations/0001_initial.py
+++ b/eventyay_paypal/migrations/0001_initial.py
@@ -5,21 +5,25 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
-        ('base', '0001_initial'),
+        ("base", "0001_initial"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='ReferencedPayPalObject',
+            name="ReferencedPayPalObject",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('reference', models.CharField(db_index=True, max_length=190, unique=True)),
-                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='base.order')),
-                ('payment', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='base.orderpayment')),
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("reference", models.CharField(db_index=True, max_length=190, unique=True)),
+                ("order", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="base.order")),
+                (
+                    "payment",
+                    models.ForeignKey(
+                        blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to="base.orderpayment"
+                    ),
+                ),
             ],
         ),
     ]

--- a/eventyay_paypal/models.py
+++ b/eventyay_paypal/models.py
@@ -3,5 +3,5 @@ from django.db import models
 
 class ReferencedPayPalObject(models.Model):
     reference = models.CharField(max_length=190, db_index=True, unique=True)
-    order = models.ForeignKey('base.Order', on_delete=models.CASCADE)
-    payment = models.ForeignKey('base.OrderPayment', null=True, blank=True, on_delete=models.CASCADE)
+    order = models.ForeignKey("base.Order", on_delete=models.CASCADE)
+    payment = models.ForeignKey("base.OrderPayment", null=True, blank=True, on_delete=models.CASCADE)

--- a/eventyay_paypal/payment.py
+++ b/eventyay_paypal/payment.py
@@ -4,7 +4,6 @@ import logging
 import urllib.parse
 from collections import OrderedDict
 from decimal import Decimal
-from typing import Union
 
 from django import forms
 from django.contrib import messages
@@ -16,7 +15,6 @@ from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 from django.utils.translation import gettext as __
 from django.utils.translation import gettext_lazy as _
-from i18nfield.strings import LazyI18nString
 from eventyay.base.decimal import round_decimal
 from eventyay.base.models import Event, Order, OrderPayment, OrderRefund, Quota
 from eventyay.base.payment import BasePaymentProvider, PaymentException
@@ -24,6 +22,7 @@ from eventyay.base.services.mail import SendMailException
 from eventyay.base.settings import SettingsSandbox
 from eventyay.helpers.urls import build_absolute_uri as build_global_uri
 from eventyay.multidomain.urlreverse import build_absolute_uri
+from i18nfield.strings import LazyI18nString
 
 from .models import ReferencedPayPalObject
 from .paypal_rest import PaypalRequestHandler
@@ -107,12 +106,8 @@ class Paypal(BasePaymentProvider):
                         label=_("Client ID"),
                         max_length=80,
                         min_length=80,
-                        help_text=_(
-                            '<a target="_blank" rel="noopener" href="{docs_url}">{text}</a>'
-                        ).format(
-                            text=_(
-                                "Click here for a tutorial on how to obtain the required keys"
-                            ),
+                        help_text=_('<a target="_blank" rel="noopener" href="{docs_url}">{text}</a>').format(
+                            text=_("Click here for a tutorial on how to obtain the required keys"),
                             docs_url="https://docs.eventyay.com/en/latest/user/payments/paypal.html",
                         ),
                     ),
@@ -161,9 +156,7 @@ class Paypal(BasePaymentProvider):
             )
         ]
 
-        d = OrderedDict(
-            fields + extra_fields + list(super().settings_form_fields.items())
-        )
+        d = OrderedDict(fields + extra_fields + list(super().settings_form_fields.items()))
 
         d.move_to_end("prefix")
         d.move_to_end("_enabled", False)
@@ -197,11 +190,7 @@ class Paypal(BasePaymentProvider):
                     }
                 ],
                 "products": ["EXPRESS_CHECKOUT"],
-                "partner_config_override": {
-                    "return_url": build_global_uri(
-                        "plugins:eventyay_paypal:oauth.return"
-                    )
-                },
+                "partner_config_override": {"return_url": build_global_uri("plugins:eventyay_paypal:oauth.return")},
                 "legal_consents": [{"type": "SHARE_DATA_CONSENT", "granted": True}],
                 "tracking_id": request.session["payment_paypal_tracking_id"],
             },
@@ -210,9 +199,7 @@ class Paypal(BasePaymentProvider):
         if errors := response_data.get("errors"):
             messages.error(
                 request,
-                _("An error occurred during connecting with PayPal: {}").format(
-                    errors["reason"]
-                ),
+                _("An error occurred during connecting with PayPal: {}").format(errors["reason"]),
             )
             return
 
@@ -226,23 +213,17 @@ class Paypal(BasePaymentProvider):
         if self.settings.connect_client_id and not self.settings.secret:
             # Use PayPal connect
             if not self.settings.connect_user_id:
-                settings_content = (
-                    "<p>{}</p>" "<a href='{}' class='btn btn-primary btn-lg'>{}</a>"
-                ).format(
+                settings_content = ("<p>{}</p><a href='{}' class='btn btn-primary btn-lg'>{}</a>").format(
                     _(
                         "To accept payments via PayPal, you will need an account at PayPal. By clicking on the "
                         "following button, you can either create a new PayPal account connect Eventyay to an existing "
                         "one."
                     ),
                     self.get_connect_url(request),
-                    _("Connect with {icon} PayPal").format(
-                        icon='<i class="fa fa-paypal"></i>'
-                    ),
+                    _("Connect with {icon} PayPal").format(icon='<i class="fa fa-paypal"></i>'),
                 )
             else:
-                settings_content = (
-                    "<button formaction='{}' class='btn btn-danger'>{}</button>"
-                ).format(
+                settings_content = ("<button formaction='{}' class='btn btn-danger'>{}</button>").format(
                     reverse(
                         "plugins:eventyay_paypal:oauth.disconnect",
                         kwargs={
@@ -253,7 +234,7 @@ class Paypal(BasePaymentProvider):
                     _("Disconnect from PayPal"),
                 )
         else:
-            settings_content = "<div class='alert alert-info'>%s<br /><code>%s</code></div>" % (
+            settings_content = "<div class='alert alert-info'>{}<br /><code>{}</code></div>".format(
                 _(
                     "Please configure a PayPal Webhook to the following endpoint in order to automatically cancel orders "
                     "when payments are refunded externally. And set webhook id to make it work properly."
@@ -263,18 +244,16 @@ class Paypal(BasePaymentProvider):
 
         if self.event.currency not in SUPPORTED_CURRENCIES:
             settings_content += (
-                '<br><br><div class="alert alert-warning">%s '
-                '<a href="https://developer.paypal.com/docs/api/reference/currency-codes/">%s</a>'
+                '<br><br><div class="alert alert-warning">{} '
+                '<a href="https://developer.paypal.com/docs/api/reference/currency-codes/">{}</a>'
                 "</div>"
-            ) % (
+            ).format(
                 _("PayPal does not process payments in your event's currency."),
-                _(
-                    "Please check this PayPal page for a complete list of supported currencies."
-                ),
+                _("Please check this PayPal page for a complete list of supported currencies."),
             )
 
         if self.event.currency in LOCAL_ONLY_CURRENCIES:
-            settings_content += '<br><br><div class="alert alert-warning">%s' "</div>" % (
+            settings_content += '<br><br><div class="alert alert-warning">{}</div>'.format(
                 _(
                     "Your event's currency is supported by PayPal as a payment and balance currency for in-country "
                     "accounts only. This means, that the receiving as well as the sending PayPal account must have been "
@@ -286,10 +265,7 @@ class Paypal(BasePaymentProvider):
         return settings_content
 
     def is_allowed(self, request: HttpRequest, total: Decimal = None) -> bool:
-        return (
-            super().is_allowed(request, total)
-            and self.event.currency in SUPPORTED_CURRENCIES
-        )
+        return super().is_allowed(request, total) and self.event.currency in SUPPORTED_CURRENCIES
 
     def payment_is_valid_session(self, request):
         return (
@@ -327,11 +303,7 @@ class Paypal(BasePaymentProvider):
                     {
                         "items": [
                             {
-                                "name": (
-                                    f"{self.settings.prefix} "
-                                    if self.settings.prefix
-                                    else ""
-                                )
+                                "name": (f"{self.settings.prefix} " if self.settings.prefix else "")
                                 + __("Order for %s") % str(request.event),
                                 "quantity": "1",
                                 "unit_amount": {
@@ -350,9 +322,7 @@ class Paypal(BasePaymentProvider):
                                 }
                             },
                         },
-                        "description": __("Event tickets for {event}").format(
-                            event=request.event.name
-                        ),
+                        "description": __("Event tickets for {event}").format(event=request.event.name),
                         "payee": payee,
                     }
                 ],
@@ -441,9 +411,7 @@ class Paypal(BasePaymentProvider):
                 if request.session.get("iframe_session", False):
                     signer = signing.Signer(salt="safe-redirect")
                     return (
-                        build_absolute_uri(
-                            request.event, "plugins:eventyay_paypal:redirect"
-                        )
+                        build_absolute_uri(request.event, "plugins:eventyay_paypal:redirect")
                         + "?url="
                         + urllib.parse.quote(signer.sign(href))
                     )
@@ -478,9 +446,7 @@ class Paypal(BasePaymentProvider):
         paypal_payer = request.session.get("payment_paypal_payer", "")
         if not order_id or not paypal_payer:
             raise PaymentException(
-                _(
-                    "We were unable to process your payment. See below for details on how to proceed."
-                )
+                _("We were unable to process your payment. See below for details on how to proceed.")
             )
 
         order_response = self.paypal_request_handler.get_order(order_id=order_id)
@@ -494,21 +460,11 @@ class Paypal(BasePaymentProvider):
 
         order_detail = order_response.get("response")
         with contextlib.suppress(ReferencedPayPalObject.MultipleObjectsReturned):
-            ReferencedPayPalObject.objects.get_or_create(
-                order=payment.order, payment=payment, reference=order_id
-            )
+            ReferencedPayPalObject.objects.get_or_create(order=payment.order, payment=payment, reference=order_id)
 
         if (
-            str(
-                safe_get(
-                    order_detail.get("purchase_units", [{}])[0], ["amount", "value"]
-                )
-            )
-            != str(payment.amount)
-            or safe_get(
-                order_detail.get("purchase_units", [{}])[0], ["amount", "currency_code"]
-            )
-            != self.event.currency
+            str(safe_get(order_detail.get("purchase_units", [{}])[0], ["amount", "value"])) != str(payment.amount)
+            or safe_get(order_detail.get("purchase_units", [{}])[0], ["amount", "currency_code"]) != self.event.currency
         ):
             logger.error(
                 "Value mismatch: Payment %s vs paypal trans %s",
@@ -524,17 +480,13 @@ class Paypal(BasePaymentProvider):
                 }
             )
             raise PaymentException(
-                _(
-                    "We were unable to process your payment. See below for details on how to proceed."
-                )
+                _("We were unable to process your payment. See below for details on how to proceed.")
             )
 
         if order_detail["status"] == "APPROVED":
-            description = (
-                f"{self.settings.prefix} " if self.settings.prefix else ""
-            ) + __("Order {order} for {event}").format(
-                event=request.event.name, order=payment.order.code
-            )
+            description = (f"{self.settings.prefix} " if self.settings.prefix else "") + __(
+                "Order {order} for {event}"
+            ).format(event=request.event.name, order=payment.order.code)
 
             update_response = self.paypal_request_handler.update_order(
                 order_id=order_id,
@@ -554,9 +506,7 @@ class Paypal(BasePaymentProvider):
                     "Unable to patch order %s in Paypal: %s",
                 )
 
-            capture_response = self.paypal_request_handler.capture_order(
-                order_id=order_id
-            )
+            capture_response = self.paypal_request_handler.capture_order(order_id=order_id)
             if errors := capture_response.get("errors"):
                 handle_paypal_error(
                     errors,
@@ -568,9 +518,7 @@ class Paypal(BasePaymentProvider):
             captured_order = capture_response.get("response")
             for purchase_unit in captured_order.get("purchase_units", []):
                 for capture in safe_get(purchase_unit, ["payments", "captures"], []):
-                    with contextlib.suppress(
-                        ReferencedPayPalObject.MultipleObjectsReturned
-                    ):
+                    with contextlib.suppress(ReferencedPayPalObject.MultipleObjectsReturned):
                         ReferencedPayPalObject.objects.get_or_create(
                             order=payment.order,
                             payment=payment,
@@ -593,15 +541,11 @@ class Paypal(BasePaymentProvider):
             payment.fail(info=captured_order)
             logger.error("Invalid state: %s", repr(captured_order))
             raise PaymentException(
-                _(
-                    "We were unable to process your payment. See below for details on how to proceed."
-                )
+                _("We were unable to process your payment. See below for details on how to proceed.")
             )
 
         if payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED:
-            logger.warning(
-                "PayPal success event even though order is already marked as paid"
-            )
+            logger.warning("PayPal success event even though order is already marked as paid")
             return
 
         try:
@@ -611,9 +555,7 @@ class Paypal(BasePaymentProvider):
         except Quota.QuotaExceededException as e:
             raise PaymentException(str(e)) from e
         except SendMailException:
-            messages.warning(
-                request, _("There was an error sending the confirmation mail.")
-            )
+            messages.warning(request, _("There was an error sending the confirmation mail."))
         return None
 
     def payment_pending_render(self, request, payment) -> str:
@@ -649,12 +591,8 @@ class Paypal(BasePaymentProvider):
     def api_payment_details(self, payment: OrderPayment):
         order_id = self.matching_id(payment)
         return {
-            "payer_email": safe_get(
-                payment.info_data, ["payer", "payer_info", "email"]
-            ),
-            "payer_id": safe_get(
-                payment.info_data, ["payer", "payer_info", "payer_id"]
-            ),
+            "payer_email": safe_get(payment.info_data, ["payer", "payer_info", "email"]),
+            "payer_id": safe_get(payment.info_data, ["payer", "payer_info", "payer_id"]),
             "cart_id": payment.info_data.get("cart", None),
             "payment_id": payment.info_data.get("id", None),
             "sale_id": order_id,
@@ -719,11 +657,7 @@ class Paypal(BasePaymentProvider):
                     "error": str(errors),
                 },
             )
-            raise PaymentException(
-                _(
-                    "An error occurred while communicating with PayPal, please try again."
-                )
-            )
+            raise PaymentException(_("An error occurred while communicating with PayPal, please try again."))
 
         refund_payment_response = refund_payment.get("response")
         refund.info = json.dumps(refund_payment_response)
@@ -744,11 +678,7 @@ class Paypal(BasePaymentProvider):
                     "error": str(errors),
                 },
             )
-            raise PaymentException(
-                _(
-                    "An error occurred while communicating with PayPal, please try again."
-                )
-            )
+            raise PaymentException(_("An error occurred while communicating with PayPal, please try again."))
 
         refund_detail_response = refund_detail.get("response")
         refund.info = json.dumps(refund_detail_response)
@@ -795,11 +725,7 @@ class Paypal(BasePaymentProvider):
                     {
                         "items": [
                             {
-                                "name": (
-                                    f"{self.settings.prefix} "
-                                    if self.settings.prefix
-                                    else ""
-                                )
+                                "name": (f"{self.settings.prefix} " if self.settings.prefix else "")
                                 + __("Order for %s") % str(request.event),
                                 "quantity": "1",
                                 "unit_amount": {
@@ -818,9 +744,7 @@ class Paypal(BasePaymentProvider):
                                 }
                             },
                         },
-                        "description": __("Event tickets for {event}").format(
-                            event=request.event.name
-                        ),
+                        "description": __("Event tickets for {event}").format(event=request.event.name),
                         "payee": payee,
                     }
                 ],
@@ -829,12 +753,8 @@ class Paypal(BasePaymentProvider):
                         "experience_context": {
                             "payment_method_preference": "UNRESTRICTED",
                             "landing_page": "LOGIN",
-                            "return_url": build_absolute_uri(
-                                request.event, "plugins:eventyay_paypal:return"
-                            ),
-                            "cancel_url": build_absolute_uri(
-                                request.event, "plugins:eventyay_paypal:abort"
-                            ),
+                            "return_url": build_absolute_uri(request.event, "plugins:eventyay_paypal:return"),
+                            "cancel_url": build_absolute_uri(request.event, "plugins:eventyay_paypal:abort"),
                         }
                     }
                 },
@@ -845,9 +765,7 @@ class Paypal(BasePaymentProvider):
             errors = order_response.get("errors")
             messages.error(
                 request,
-                _("An error occurred during connecting with PayPal: {}").format(
-                    errors["reason"]
-                ),
+                _("An error occurred during connecting with PayPal: {}").format(errors["reason"]),
             )
             return None
 
@@ -855,7 +773,7 @@ class Paypal(BasePaymentProvider):
         request.session["payment_paypal_payment"] = None
         return self._create_order(request, order_created)
 
-    def shred_payment_info(self, obj: Union[OrderPayment, OrderRefund]):
+    def shred_payment_info(self, obj: OrderPayment | OrderRefund):
         if obj.info_data:
             d = obj.info_data
             purchase_units = d.get("purchase_units", [])
@@ -872,9 +790,7 @@ class Paypal(BasePaymentProvider):
             obj.save(update_fields=["info"])
 
         for le in (
-            obj.order.all_logentries()
-            .filter(action_type="eventyay.plugins.eventyay_paypal.event")
-            .exclude(data="")
+            obj.order.all_logentries().filter(action_type="eventyay.plugins.eventyay_paypal.event").exclude(data="")
         ):
             d = le.parsed_data
             if "resource" in d:
@@ -889,12 +805,12 @@ class Paypal(BasePaymentProvider):
 
     def render_invoice_text(self, order: Order, payment: OrderPayment) -> str:
         if order.status == Order.STATUS_PAID:
-            payment_id = payment.info_data.get('id')
+            payment_id = payment.info_data.get("id")
             if not payment_id:
                 return super().render_invoice_text(order, payment)
 
             try:
-                paypal_sale_id = payment.info_data['transactions'][0]['related_resources'][0]['sale']['id']
+                paypal_sale_id = payment.info_data["transactions"][0]["related_resources"][0]["sale"]["id"]
                 return (
                     f"{_('The payment for this invoice has already been received.')}\r\n"
                     f"{_('PayPal payment ID')}: {payment_id}\r\n"
@@ -905,4 +821,4 @@ class Paypal(BasePaymentProvider):
                     f"{_('The payment for this invoice has already been received.')}\r\n"
                     f"{_('PayPal payment ID')}: {payment_id}"
                 )
-        return self.settings.get('_invoice_text', as_type=LazyI18nString, default='')
+        return self.settings.get("_invoice_text", as_type=LazyI18nString, default="")

--- a/eventyay_paypal/paypal_rest.py
+++ b/eventyay_paypal/paypal_rest.py
@@ -6,7 +6,6 @@ import time
 import urllib.parse
 import uuid
 from http import HTTPMethod
-from typing import List, Optional
 
 import jwt
 import requests
@@ -39,27 +38,13 @@ class PaypalRequestHandler:
             self.endpoint = "https://api-m.paypal.com"
 
         self.oauth_url = urllib.parse.urljoin(self.endpoint, "v1/oauth2/token")
-        self.partner_referrals_url = urllib.parse.urljoin(
-            self.endpoint, "/v2/customer/partner-referrals"
-        )
-        self.order_url = urllib.parse.urljoin(
-            self.endpoint, "v2/checkout/orders/{order_id}"
-        )
-        self.create_order_url = urllib.parse.urljoin(
-            self.endpoint, "v2/checkout/orders"
-        )
-        self.capture_order_url = urllib.parse.urljoin(
-            self.endpoint, "v2/checkout/orders/{order_id}/capture"
-        )
-        self.refund_detail_url = urllib.parse.urljoin(
-            self.endpoint, "v2/payments/refunds/{refund_id}"
-        )
-        self.refund_payment_url = urllib.parse.urljoin(
-            self.endpoint, "v2/payments/captures/{capture_id}/refund"
-        )
-        self.verify_webhook_url = urllib.parse.urljoin(
-            self.endpoint, "/v1/notifications/verify-webhook-signature"
-        )
+        self.partner_referrals_url = urllib.parse.urljoin(self.endpoint, "/v2/customer/partner-referrals")
+        self.order_url = urllib.parse.urljoin(self.endpoint, "v2/checkout/orders/{order_id}")
+        self.create_order_url = urllib.parse.urljoin(self.endpoint, "v2/checkout/orders")
+        self.capture_order_url = urllib.parse.urljoin(self.endpoint, "v2/checkout/orders/{order_id}/capture")
+        self.refund_detail_url = urllib.parse.urljoin(self.endpoint, "v2/payments/refunds/{refund_id}")
+        self.refund_payment_url = urllib.parse.urljoin(self.endpoint, "v2/payments/captures/{capture_id}/refund")
+        self.verify_webhook_url = urllib.parse.urljoin(self.endpoint, "/v1/notifications/verify-webhook-signature")
 
         self.paypal_request_id = self.get_paypal_request_id()
 
@@ -77,18 +62,12 @@ class PaypalRequestHandler:
         response_data = {}
         try:
             if method == HTTPMethod.GET:
-                response = requests.get(
-                    url, data=data, params=params, headers=headers, timeout=timeout
-                )
+                response = requests.get(url, data=data, params=params, headers=headers, timeout=timeout)
             elif method == HTTPMethod.POST:
-                response = requests.post(
-                    url, data=data, params=params, headers=headers, timeout=timeout
-                )
+                response = requests.post(url, data=data, params=params, headers=headers, timeout=timeout)
             elif method == HTTPMethod.PATCH:
                 # Patch request return empty body
-                requests.patch(
-                    url, data=data, params=params, headers=headers, timeout=timeout
-                )
+                requests.patch(url, data=data, params=params, headers=headers, timeout=timeout)
                 return {}
 
             # In case request failed, capture specific reason
@@ -123,9 +102,7 @@ class PaypalRequestHandler:
     @staticmethod
     def check_expired_token(access_token_data: dict, buffer_time: int = 300) -> bool:
         current_time = time.time()
-        expiration_time = (
-            access_token_data["created_at"] + access_token_data["expires_in"]
-        )
+        expiration_time = access_token_data["created_at"] + access_token_data["expires_in"]
         return (current_time + buffer_time) > expiration_time
 
     @staticmethod
@@ -138,9 +115,7 @@ class PaypalRequestHandler:
 
     def set_cache_token_key(self) -> str:
         if self.connect_client_id and self.secret_key:
-            hash_code = hashlib.sha256(
-                "".join([self.connect_client_id, self.secret_key]).encode()
-            ).hexdigest()
+            hash_code = hashlib.sha256("".join([self.connect_client_id, self.secret_key]).encode()).hexdigest()
             self.cache_token_key = f"paypal_token_hash_{hash_code}"
             # Fernet key must be 32 urlsafe b64encode
             self.fernet = Fernet(base64.urlsafe_b64encode(hash_code[:32].encode()))
@@ -169,7 +144,7 @@ class PaypalRequestHandler:
             payload={"iss": self.connect_client_id, "payer_id": merchant_id},
         )
 
-    def get_access_token(self) -> Optional[str]:
+    def get_access_token(self) -> str | None:
         """
         https://developer.paypal.com/api/rest/authentication/
         Get access token data from cache and check expiration
@@ -189,18 +164,14 @@ class PaypalRequestHandler:
             )
 
             if errors := access_token_response.get("errors"):
-                logger.error(
-                    "Error getting access token from Paypal: %s", errors["reason"]
-                )
+                logger.error("Error getting access token from Paypal: %s", errors["reason"])
                 return {}
 
             access_token_data = access_token_response.get("response")
             # Add this key value to check for token expiration later
             access_token_data["created_at"] = time.time()
             # Encrypt access token data and set in cache
-            encrypted_access_token_data = self.fernet.encrypt(
-                json.dumps(access_token_data).encode()
-            )
+            encrypted_access_token_data = self.fernet.encrypt(json.dumps(access_token_data).encode())
             cache.set(self.cache_token_key, encrypted_access_token_data, 3600 * 2)
             return access_token_data
 
@@ -209,9 +180,7 @@ class PaypalRequestHandler:
         if encrypted_access_token_data is None:
             access_token_data = request_new_access_token()
         else:
-            access_token_data = json.loads(
-                self.fernet.decrypt(encrypted_access_token_data).decode()
-            )
+            access_token_data = json.loads(self.fernet.decrypt(encrypted_access_token_data).decode())
 
             if self.check_expired_token(access_token_data):
                 access_token_data = request_new_access_token()
@@ -272,7 +241,7 @@ class PaypalRequestHandler:
             },
         )
 
-    def update_order(self, order_id: str, update_data: List[dict]) -> dict:
+    def update_order(self, order_id: str, update_data: list[dict]) -> dict:
         """
         https://developer.paypal.com/docs/api/orders/v2/#orders_patch
         """

--- a/eventyay_paypal/signals.py
+++ b/eventyay_paypal/signals.py
@@ -6,31 +6,35 @@ from django.dispatch import receiver
 from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.forms import SecretKeySettingsField
-from eventyay.base.signals import (logentry_display, register_global_settings,
-                                 register_payment_providers,
-                                 requiredaction_display)
+from eventyay.base.signals import (
+    logentry_display,
+    register_global_settings,
+    register_payment_providers,
+    requiredaction_display,
+)
 
 
 @receiver(register_payment_providers, dispatch_uid="payment_paypal")
 def register_payment_provider(sender, **kwargs):
     from .payment import Paypal
+
     return Paypal
 
 
 @receiver(signal=logentry_display, dispatch_uid="paypal_logentry_display")
 def pretixcontrol_logentry_display(sender, logentry, **kwargs):
-    if logentry.action_type != 'eventyay.plugins.eventyay_paypal.event':
+    if logentry.action_type != "eventyay.plugins.eventyay_paypal.event":
         return
 
     data = json.loads(logentry.data)
-    event_type = data.get('event_type')
+    event_type = data.get("event_type")
     text = None
     plains = {
-        'PAYMENT.SALE.COMPLETED': _('Payment completed.'),
-        'PAYMENT.SALE.DENIED': _('Payment denied.'),
-        'PAYMENT.SALE.REFUNDED': _('Payment refunded.'),
-        'PAYMENT.SALE.REVERSED': _('Payment reversed.'),
-        'PAYMENT.SALE.PENDING': _('Payment pending.'),
+        "PAYMENT.SALE.COMPLETED": _("Payment completed."),
+        "PAYMENT.SALE.DENIED": _("Payment denied."),
+        "PAYMENT.SALE.REFUNDED": _("Payment refunded."),
+        "PAYMENT.SALE.REVERSED": _("Payment reversed."),
+        "PAYMENT.SALE.PENDING": _("Payment pending."),
     }
 
     if event_type in plains:
@@ -39,44 +43,55 @@ def pretixcontrol_logentry_display(sender, logentry, **kwargs):
         text = event_type
 
     if text:
-        return _('PayPal reported an event: {}').format(text)
+        return _("PayPal reported an event: {}").format(text)
 
 
 @receiver(signal=requiredaction_display, dispatch_uid="paypal_requiredaction_display")
 def pretixcontrol_action_display(sender, action, request, **kwargs):
-    if not action.action_type.startswith('eventyay.plugins.eventyay_paypal'):
+    if not action.action_type.startswith("eventyay.plugins.eventyay_paypal"):
         return
 
     data = json.loads(action.data)
 
-    if action.action_type == 'eventyay.plugins.eventyay_paypal.refund':
-        template = get_template('plugins/paypal/action_refund.html')
-    elif action.action_type == 'eventyay.plugins.eventyay_paypal.overpaid':
-        template = get_template('plugins/paypal/action_overpaid.html')
-    elif action.action_type == 'eventyay.plugins.eventyay_paypal.double':
-        template = get_template('plugins/paypal/action_double.html')
+    if action.action_type == "eventyay.plugins.eventyay_paypal.refund":
+        template = get_template("plugins/paypal/action_refund.html")
+    elif action.action_type == "eventyay.plugins.eventyay_paypal.overpaid":
+        template = get_template("plugins/paypal/action_overpaid.html")
+    elif action.action_type == "eventyay.plugins.eventyay_paypal.double":
+        template = get_template("plugins/paypal/action_double.html")
 
-    ctx = {'data': data, 'event': sender, 'action': action}
+    ctx = {"data": data, "event": sender, "action": action}
     return template.render(ctx, request)
 
 
-@receiver(register_global_settings, dispatch_uid='paypal_global_settings')
+@receiver(register_global_settings, dispatch_uid="paypal_global_settings")
 def register_global_settings(sender, **kwargs):
-    return OrderedDict([
-        ('payment_paypal_connect_client_id', forms.CharField(
-            label=_('PayPal Connect: Client ID'),
-            required=False,
-        )),
-        ('payment_paypal_connect_secret_key', SecretKeySettingsField(
-            label=_('PayPal Connect: Secret key'),
-            required=False,
-        )),
-        ('payment_paypal_connect_endpoint', forms.ChoiceField(
-            label=_('PayPal Connect Endpoint'),
-            initial='live',
-            choices=(
-                ('live', 'Live'),
-                ('sandbox', 'Sandbox'),
+    return OrderedDict(
+        [
+            (
+                "payment_paypal_connect_client_id",
+                forms.CharField(
+                    label=_("PayPal Connect: Client ID"),
+                    required=False,
+                ),
             ),
-        )),
-    ])
+            (
+                "payment_paypal_connect_secret_key",
+                SecretKeySettingsField(
+                    label=_("PayPal Connect: Secret key"),
+                    required=False,
+                ),
+            ),
+            (
+                "payment_paypal_connect_endpoint",
+                forms.ChoiceField(
+                    label=_("PayPal Connect Endpoint"),
+                    initial="live",
+                    choices=(
+                        ("live", "Live"),
+                        ("sandbox", "Sandbox"),
+                    ),
+                ),
+            ),
+        ]
+    )

--- a/eventyay_paypal/urls.py
+++ b/eventyay_paypal/urls.py
@@ -2,25 +2,37 @@ from django.urls import include
 from django.urls import re_path as url
 from eventyay.multidomain import event_url
 
-from .views import (abort, oauth_disconnect, oauth_return, redirect_view,
-                    success, webhook)
+from .views import (
+    abort,
+    oauth_disconnect,
+    oauth_return,
+    redirect_view,
+    success,
+    webhook,
+)
 
 event_patterns = [
-    url(r'^paypal/', include([
-        url(r'^abort/$', abort, name='abort'),
-        url(r'^return/$', success, name='return'),
-        url(r'^redirect/$', redirect_view, name='redirect'),
-
-        url(r'w/(?P<cart_namespace>[a-zA-Z0-9]{16})/abort/', abort, name='abort'),
-        url(r'w/(?P<cart_namespace>[a-zA-Z0-9]{16})/return/', success, name='return'),
-
-        event_url(r'^webhook/$', webhook, name='webhook', require_live=False),
-    ])),
+    url(
+        r"^paypal/",
+        include(
+            [
+                url(r"^abort/$", abort, name="abort"),
+                url(r"^return/$", success, name="return"),
+                url(r"^redirect/$", redirect_view, name="redirect"),
+                url(r"w/(?P<cart_namespace>[a-zA-Z0-9]{16})/abort/", abort, name="abort"),
+                url(r"w/(?P<cart_namespace>[a-zA-Z0-9]{16})/return/", success, name="return"),
+                event_url(r"^webhook/$", webhook, name="webhook", require_live=False),
+            ]
+        ),
+    ),
 ]
 
 urlpatterns = [
-    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/paypal/disconnect/',
-        oauth_disconnect, name='oauth.disconnect'),
-    url(r'^_paypal/webhook/$', webhook, name='webhook'),
-    url(r'^_paypal/oauth_return/$', oauth_return, name='oauth.return'),
+    url(
+        r"^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/paypal/disconnect/",
+        oauth_disconnect,
+        name="oauth.disconnect",
+    ),
+    url(r"^_paypal/webhook/$", webhook, name="webhook"),
+    url(r"^_paypal/oauth_return/$", oauth_return, name="oauth.return"),
 ]

--- a/eventyay_paypal/utils.py
+++ b/eventyay_paypal/utils.py
@@ -1,4 +1,3 @@
-
 def safe_get(data, keys, default=None):
     """
     Recursively calls .get() on a dictionary to safely access nested keys.

--- a/eventyay_paypal/views.py
+++ b/eventyay_paypal/views.py
@@ -1,7 +1,7 @@
 import contextlib
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from http import HTTPStatus
 
@@ -79,10 +79,7 @@ def oauth_return(request, *args, **kwargs):
 
     messages.success(
         request,
-        _(
-            "Your PayPal account is now connected to Eventyay. You can change the settings in "
-            "detail below."
-        ),
+        _("Your PayPal account is now connected to Eventyay. You can change the settings in detail below."),
     )
 
     return redirect(
@@ -108,9 +105,7 @@ def success(request, *args, **kwargs):
         urlkwargs["cart_namespace"] = kwargs["cart_namespace"]
 
     if request.session.get("payment_paypal_payment"):
-        payment = OrderPayment.objects.get(
-            pk=request.session.get("payment_paypal_payment")
-        )
+        payment = OrderPayment.objects.get(pk=request.session.get("payment_paypal_payment"))
     else:
         payment = None
 
@@ -122,20 +117,14 @@ def success(request, *args, **kwargs):
             except PaymentException as e:
                 messages.error(request, str(e))
                 urlkwargs["step"] = "payment"
-                return redirect(
-                    eventreverse(
-                        request.event, "presale:event.checkout", kwargs=urlkwargs
-                    )
-                )
+                return redirect(eventreverse(request.event, "presale:event.checkout", kwargs=urlkwargs))
             if resp:
                 return resp
     else:
         messages.error(request, _("Invalid response from PayPal received."))
         logger.error("Session did not contain payment_paypal_order_id")
         urlkwargs["step"] = "payment"
-        return redirect(
-            eventreverse(request.event, "presale:event.checkout", kwargs=urlkwargs)
-        )
+        return redirect(eventreverse(request.event, "presale:event.checkout", kwargs=urlkwargs))
 
     if payment:
         return redirect(
@@ -147,18 +136,14 @@ def success(request, *args, **kwargs):
             + ("?paid=yes" if payment.order.status == Order.STATUS_PAID else "")
         )
     urlkwargs["step"] = "confirm"
-    return redirect(
-        eventreverse(request.event, "presale:event.checkout", kwargs=urlkwargs)
-    )
+    return redirect(eventreverse(request.event, "presale:event.checkout", kwargs=urlkwargs))
 
 
 def abort(request, *args, **kwargs):
     messages.error(request, _("It looks like you canceled the PayPal payment"))
 
     if request.session.get("payment_paypal_payment"):
-        payment = OrderPayment.objects.get(
-            pk=request.session.get("payment_paypal_payment")
-        )
+        payment = OrderPayment.objects.get(pk=request.session.get("payment_paypal_payment"))
     else:
         payment = None
 
@@ -172,11 +157,7 @@ def abort(request, *args, **kwargs):
             + ("?paid=yes" if payment.order.status == Order.STATUS_PAID else "")
         )
     else:
-        return redirect(
-            eventreverse(
-                request.event, "presale:event.checkout", kwargs={"step": "payment"}
-            )
-        )
+        return redirect(eventreverse(request.event, "presale:event.checkout", kwargs={"step": "payment"}))
 
 
 def check_webhook_signature(request, event, event_json, prov) -> bool:
@@ -202,10 +183,8 @@ def check_webhook_signature(request, event, event_json, prov) -> bool:
         return False
 
     # Prevent replay attacks: check timestamp
-    current_time = datetime.now(timezone.utc)
-    transmission_time = datetime.fromisoformat(
-        request.headers.get("PAYPAL-TRANSMISSION-TIME")
-    )
+    current_time = datetime.now(UTC)
+    transmission_time = datetime.fromisoformat(request.headers.get("PAYPAL-TRANSMISSION-TIME"))
     if current_time - transmission_time > timedelta(minutes=7):
         logger.error("Paypal webhook timestamp is too old.")
         return False
@@ -222,11 +201,7 @@ def check_webhook_signature(request, event, event_json, prov) -> bool:
         }
     )
 
-    if (
-        verify_response.get("errors")
-        or safe_get(verify_response, ["response", "verification_status"], "")
-        == "FAILURE"
-    ):
+    if verify_response.get("errors") or safe_get(verify_response, ["response", "verification_status"], "") == "FAILURE":
         errors = verify_response.get("errors")
         logger.error("Unable to verify signature of webhook: %s", errors["reason"])
         return False
@@ -255,19 +230,12 @@ def parse_webhook_event(request, event_json):
     references = [payment_id]
 
     # For filtering reference, there are a lot of ids appear within json__event
-    if ref_order_id := (
-        safe_get(
-            event_json,
-            ["resource", "supplementary_data", "related_ids", "order_id"]
-        )
-    ):
+    if ref_order_id := (safe_get(event_json, ["resource", "supplementary_data", "related_ids", "order_id"])):
         references.append(ref_order_id)
 
     # Grasp the corresponding RPO
     rpo = (
-        ReferencedPayPalObject.objects.select_related("order", "order__event")
-        .filter(reference__in=references)
-        .first()
+        ReferencedPayPalObject.objects.select_related("order", "order__event").filter(reference__in=references).first()
     )
 
     if rpo:
@@ -312,14 +280,8 @@ def extract_order_and_payment(payment_id, event, event_json, prov, rpo=None):
         )
         payment = None
         for p in payments:
-            if (
-                "info_data" in p
-                and "purchase_units" in p.info_data
-                and p.info_data["purchase_units"]
-            ):
-                for capture in safe_get(
-                    p.info_data["purchase_units"][0], ["payments", "captures"], []
-                ):
+            if "info_data" in p and "purchase_units" in p.info_data and p.info_data["purchase_units"]:
+                for capture in safe_get(p.info_data["purchase_units"][0], ["payments", "captures"], []):
                     if capture.get("status") in [
                         "COMPLETED",
                         "PARTIALLY_REFUNDED",
@@ -354,9 +316,7 @@ def webhook(request, *args, **kwargs):
     if not check_webhook_signature(request, event, event_json, prov):
         return HttpResponse("Unable to verify signature of webhook", status=HTTPStatus.BAD_REQUEST)
 
-    order_detail, payment = extract_order_and_payment(
-        payment_id, event, event_json, prov, rpo
-    )
+    order_detail, payment = extract_order_and_payment(payment_id, event, event_json, prov, rpo)
     if order_detail is None or payment is None:
         return HttpResponse("Order or payment not found", status=HTTPStatus.BAD_REQUEST)
 
@@ -371,20 +331,14 @@ def webhook(request, *args, **kwargs):
         if errors := refund_response.get("errors"):
             logger.error("Paypal error on webhook: %s", errors["reason"])
             logger.exception("PayPal error on webhook. Event data: %s", str(event_json))
-            return HttpResponse(
-                f'Refund {refund_id_in_event} not found', status=HTTPStatus.BAD_REQUEST
-            )
+            return HttpResponse(f"Refund {refund_id_in_event} not found", status=HTTPStatus.BAD_REQUEST)
 
         refund_detail = refund_response.get("response")
         if refund_id := refund_detail.get("id"):
-            known_refunds = {
-                refund.info_data.get("id"): refund for refund in payment.refunds.all()
-            }
+            known_refunds = {refund.info_data.get("id"): refund for refund in payment.refunds.all()}
             if refund_id not in known_refunds:
                 payment.create_external_refund(
-                    amount=abs(
-                        Decimal(safe_get(refund_detail, ["amount", "value"], "0.00"))
-                    ),
+                    amount=abs(Decimal(safe_get(refund_detail, ["amount", "value"], "0.00"))),
                     info=json.dumps(refund_detail),
                 )
             elif know_refund := known_refunds.get(refund_id):
@@ -436,18 +390,14 @@ def webhook(request, *args, **kwargs):
                 request.session["payment_paypal_order_id"] = payment.info_data.get("id")
                 payment.payment_provider.execute_payment(request, payment)
             except PaymentException as e:
-                logger.error(
-                    "Error executing approved payment in webhook: payment not yet populated."
-                )
+                logger.error("Error executing approved payment in webhook: payment not yet populated.")
                 logger.exception("Unable to execute payment in webhook: %s", str(e))
         elif order_detail.get("status") == "COMPLETED":
             captured = False
             captures_completed = True
             for purchase_unit in order_detail.get("purchase_units", []):
                 for capture in safe_get(purchase_unit, ["payment", "captures"], []):
-                    with contextlib.suppress(
-                        ReferencedPayPalObject.MultipleObjectsReturned
-                    ):
+                    with contextlib.suppress(ReferencedPayPalObject.MultipleObjectsReturned):
                         ReferencedPayPalObject.objects.get_or_create(
                             order=payment.order,
                             payment=payment,
@@ -467,9 +417,11 @@ def webhook(request, *args, **kwargs):
                     payment.save(update_fields=["info"])
                     payment.confirm()
 
-    if payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED and order_detail[
-        "status"
-    ] in ("PARTIALLY_REFUNDED", "REFUNDED", "COMPLETED"):
+    if payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED and order_detail["status"] in (
+        "PARTIALLY_REFUNDED",
+        "REFUNDED",
+        "COMPLETED",
+    ):
         handle_payment_state_confirmed()
     elif payment.state in (
         OrderPayment.PAYMENT_STATE_PENDING,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ maintainers = [
 
 dependencies = []
 
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.9",
+]
+
 [project.entry-points."pretix.plugin"]
 eventyay_paypal = "eventyay_paypal:PretixPluginMeta"
 
@@ -39,3 +44,19 @@ version = {attr = "eventyay_paypal.__version__"}
 [tool.setuptools.packages.find]
 include = ["eventyay*"]
 namespaces = false
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/migrations/*.py" = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ namespaces = false
 [tool.ruff]
 line-length = 120
 target-version = "py311"
+extend-exclude = ["**/migrations"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP"]


### PR DESCRIPTION
## Summary
- Adds Ruff as the single Python lint and format tool.
- Configures Ruff in `pyproject.toml` and runs `ruff check` / `ruff format --check` in CI.
- Applies Ruff formatting and safe lint fixes, and documents the local commands.

Resolves #7

## Test plan
- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] CI Ruff job is green on this PR

## Summary by Sourcery

Adopt Ruff as the project’s unified Python linting and formatting tool.

Enhancements:
- Replace the separate Python linting and formatting tools with Ruff and standardize the codebase on its checks and formatting.

Build:
- Add Ruff as a development dependency and configure its linting, formatting, target Python version, and exclusions in pyproject.toml.

CI:
- Add a GitHub Actions workflow to run Ruff lint and format checks on pushes and pull requests.

Documentation:
- Document the Ruff installation and local linting and formatting commands.

Chores:
- Apply Ruff formatting and safe lint fixes throughout the plugin, including modernized type annotations and import organization.