### PR TITLE
chore: use uv.lock for Dependabot Python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    target-branch: "dev"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "eventyay-paypal"
+source = { editable = "." }


### PR DESCRIPTION
## Summary
- Adds a \`uv.lock\` so Python dependencies are pinned the same way as eventyay-stripe.
- Switches Dependabot from \`pip\` to \`uv\` so \`pyproject.toml\` and \`uv.lock\` stay in sync.
- Keeps weekly GitHub Actions updates on \`dev\`.

The runtime package still has no third-party dependencies. The lock exists so Dependabot can update it when extras (for example Ruff) are added.

## Test plan
- [ ] Confirm \`uv.lock\` is committed at the repo root
- [ ] Confirm Dependabot config uses \`package-ecosystem: uv\`
- [ ] After merge, confirm Dependabot can open Python and Actions update PRs against \`dev\`

## Summary by Sourcery

Adopt uv lockfile management and route automated dependency updates to the dev branch.

Enhancements:
- Add a committed uv.lock file to establish lockfile-based Python dependency management.

CI:
- Configure Dependabot to use the uv ecosystem for Python updates and target both Python and GitHub Actions updates at the dev branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update pull requests now target the `dev` branch.
  * Python package updates are managed through the `uv` ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->